### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/filter.t
+++ b/t/filter.t
@@ -1,8 +1,7 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib', 'lib' }
+use lib <blib/lib lib>;
 
-use Test;
-use Net::Pcap;
+use Test; use Net::Pcap;
 
 plan 1;
 

--- a/t/open_offline.t
+++ b/t/open_offline.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib', 'lib' }
+use lib <blib/lib lib>;
 
 use Test;
 use Net::Pcap;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
